### PR TITLE
Test cases should time out

### DIFF
--- a/lib/FileExecutor.js
+++ b/lib/FileExecutor.js
@@ -2,10 +2,11 @@ var spawn = require('child_process').spawn;
 
 module.exports = FileExecutor;
 function FileExecutor(options) {
-  this._file   = options.file;
-  this._bin    = process.execPath;
-  this._cwd    = options.cwd || process.cwd();
-  this._output = '';
+  this._file     = options.file;
+  this._bin      = process.execPath;
+  this._cwd      = options.cwd || process.cwd();
+  this._timeout  = options.timeout || 1000;
+  this._output   = '';
 }
 
 FileExecutor.prototype.execute = function(cb) {
@@ -15,7 +16,13 @@ FileExecutor.prototype.execute = function(cb) {
   this._capture(child.stdout);
   this._capture(child.stderr);
 
+  var timeout = setTimeout(function () {
+    self._output += self.relativePath() + ' timed out';
+    child.kill();
+  }, this._timeout);
+
   child.on('exit', function(code, signal) {
+    clearTimeout(timeout);
     cb(self._errorFor(code, signal), self._output);
   });
 };

--- a/lib/Runner.js
+++ b/lib/Runner.js
@@ -5,8 +5,9 @@ var util         = require('util');
 module.exports = Runner;
 util.inherits(Runner, EventEmitter);
 function Runner(options) {
-  this._files = [].concat(options.files);
-  this._cwd   = options.cwd || process.cwd();
+  this._files   = [].concat(options.files);
+  this._cwd     = options.cwd || process.cwd();
+  this._timeout = options.timeout;
 }
 
 Runner.prototype.execute = function() {
@@ -22,7 +23,7 @@ Runner.prototype._nextFile = function() {
   }
 
   var self         = this;
-  var executor     = new FileExecutor({file: file, cwd: this._cwd});
+  var executor     = new FileExecutor({file: file, cwd: this._cwd, timeout: this._timeout});
   var relativePath = executor.relativePath();
 
   this.emit('fileStart', relativePath);

--- a/test/fixture/3.js
+++ b/test/fixture/3.js
@@ -1,0 +1,1 @@
+setTimeout(function() {}, 500);

--- a/test/integration/FileExecutor/test-times-out.js
+++ b/test/integration/FileExecutor/test-times-out.js
@@ -1,0 +1,16 @@
+var assert       = require('assert');
+var FileExecutor = require('../../../lib/FileExecutor');
+var path         = require('path');
+var rootDir      = path.join(__dirname, '../../..');
+var fixture      = path.join(__dirname, '../../fixture/3.js');
+
+var executor   = new FileExecutor({file: fixture, cwd: rootDir, timeout: 50});
+var executed = false;
+executor.execute(function(err, output) {
+  assert.equal(output, 'test/fixture/3.js timed out');
+  executed = true;
+});
+
+process.on('exit', function() {
+  assert.ok(executed);
+});

--- a/test/integration/FileFinder/test-finds-all-fixtures.js
+++ b/test/integration/FileFinder/test-finds-all-fixtures.js
@@ -25,6 +25,7 @@ process.on('exit', function() {
   assert.deepEqual(files, [
     fixture + '/1.txt',
     fixture + '/2.js',
+    fixture + '/3.js',
     fixture + '/a/a1.txt',
     fixture + '/a/a2.js',
     fixture + '/b/b1.txt',

--- a/test/integration/Runner/test-runs-files.js
+++ b/test/integration/Runner/test-runs-files.js
@@ -3,8 +3,8 @@ var Runner  = require('../../../lib/Runner');
 var path    = require('path');
 var fixture = path.join(__dirname, '../../fixture');
 
-var files  = [fixture + '/2.js', fixture + '/a/a2.js'];
-var runner = new Runner({files: files, cwd: fixture});
+var files  = [fixture + '/2.js', fixture + '/3.js', fixture + '/a/a2.js'];
+var runner = new Runner({files: files, cwd: fixture, timeout: 100});
 
 var events = [];
 runner
@@ -33,6 +33,14 @@ process.on('exit', function() {
   assert.deepEqual(event.slice(0, 2), ['fileEnd', '2.js']);
   assert.ok(event.slice(2, 3)[0] instanceof Error);
   assert.equal(event.slice(3, 4)[0], 'I am stderr\nI am stdout\n');
+
+  event = events.shift();
+  assert.deepEqual(event, ['fileStart', '3.js']);
+
+  event = events.shift();
+  assert.deepEqual(event.slice(0, 2), ['fileEnd', '3.js']);
+  assert.ok(event.slice(2, 3)[0] instanceof Error);
+  assert.equal(event.slice(3, 4)[0], '3.js timed out');
 
   event = events.shift();
   assert.deepEqual(event, ['fileStart', 'a/a2.js']);


### PR DESCRIPTION
It happened a couple of times that a timer was not cleared properly in a test case causing the test execution to hang and eventually pass after a couple of seconds.

`Runner` and `FileExecutor` are now configurable with a timeout config
value which defaults to one second. If the node process does not exit
within the specified timeout it is killed.
