### PR TITLE
Print out stdout, even if test passes.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -24,9 +24,15 @@ require('urun')(__dirname);
 ```
 
 You now get a nice progress indication, as well as detailed output for each
-test that fails.
+test that fails. By default output is only printed for tests that fail. To enable
+detailed output for all tests, including those passing, include verbose: true
+in the list of options.
 
-The only other feature is specifying a regex for the files to run (default is
+```js
+require('urun')(__dirname, { verbose: true });
+```
+
+Another feature is specifying a regex for the files to run (default is
 `/test-.+\.js$/`), for example:
 
 ```js

--- a/index.js
+++ b/index.js
@@ -4,7 +4,10 @@ var Runner       = require('./lib/Runner');
 
 module.exports = function(dir, options) {
   var options  = options || {};
-  var include  = options.include  || /test-.+\.js$/;
+  var include  = options.include || /test-.+\.js$/;
+  var verbose  = options.verbose;
+  if (verbose !== true) verbose = false;
+
   var Reporter = require('./lib/reporter/'
     + (process.env.REPORTER || options.reporter || 'BashReporter'));
 
@@ -17,7 +20,7 @@ module.exports = function(dir, options) {
     files = filter.filter(files);
 
     var runner   = new Runner({files: files});
-    var reporter = new Reporter({runner: runner});
+    var reporter = new Reporter({runner: runner, verbose: verbose});
     runner.execute();
   });
 };

--- a/lib/reporter/BashReporter.js
+++ b/lib/reporter/BashReporter.js
@@ -3,6 +3,7 @@ var str = require('../str');
 module.exports = BashReporter;
 function BashReporter(options) {
   this._runner      = options.runner;
+  this._verbose     = options.verbose;
   this._currentFile = null;
   this._lastLine    = null;
   this._start       = null;
@@ -29,7 +30,7 @@ BashReporter.prototype._handleFileStart = function(file) {
 };
 
 BashReporter.prototype._handleFileEnd = function(file, err, output) {
-  if (output) {
+  if (output && (this._verbose || err)) {
     if (output.substr(0, 1) !== '\n') output = '\n' + output;
     output = output.replace(/^/mg, '  ');
     process.stdout.write('\n' + output + '\n');

--- a/lib/reporter/BashReporter.js
+++ b/lib/reporter/BashReporter.js
@@ -29,13 +29,14 @@ BashReporter.prototype._handleFileStart = function(file) {
 };
 
 BashReporter.prototype._handleFileEnd = function(file, err, output) {
-  if (err) {
-    this._fail++;
-
+  if (output) {
     if (output.substr(0, 1) !== '\n') output = '\n' + output;
     output = output.replace(/^/mg, '  ');
-
     process.stdout.write('\n' + output + '\n');
+  }
+
+  if (err) {
+    this._fail++;
   } else {
     this._pass++;
   }

--- a/lib/reporter/BashTapReporter.js
+++ b/lib/reporter/BashTapReporter.js
@@ -17,11 +17,11 @@ BashTapReporter.prototype._handleStart = function(files) {
 BashTapReporter.prototype._handleFileEnd = function(file, err, output) {
   if (err) {
     console.log('not ok %d %s', this._count, this._tapTitle(file));
-    console.log(output.replace(/^/gm, '  '));
     this._fail = true;
   } else {
     console.log('ok %d %s', this._count, this._tapTitle(file));
   }
+  if (output) console.log(output.replace(/^/gm, '  '));
   this._count++;
 };
 

--- a/lib/reporter/BashTapReporter.js
+++ b/lib/reporter/BashTapReporter.js
@@ -2,6 +2,7 @@ module.exports = BashTapReporter;
 
 function BashTapReporter(options) {
   this._runner      = options.runner;
+  this._verbose     = options.verbose;
   this._fail        = false;
   this._count       = 1;
 
@@ -21,7 +22,7 @@ BashTapReporter.prototype._handleFileEnd = function(file, err, output) {
   } else {
     console.log('ok %d %s', this._count, this._tapTitle(file));
   }
-  if (output) console.log(output.replace(/^/gm, '  '));
+  if (output && (this._verbose || err)) console.log(output.replace(/^/gm, '  '));
   this._count++;
 };
 


### PR DESCRIPTION
I'd like to see any console.log output that is in a test regardless of whether it passes or not. This simplifies debugging tests. For example, if I add a console.log statement to a test, I would expect it to print regardless of the test passing or not, however currently it does not.
