### PR TITLE
Update package.json to include the repository key

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,6 @@
   "version": "0.0.8",
   "homepage": "https://github.com/felixge/node-urun",
   "repository": {
-    "url": ""
-  },
-  "repository": {
     "type": "git",
     "url": "https://github.com/felixge/node-urun.git"
   },

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
   "repository": {
     "url": ""
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/felixge/node-urun.git"
+  },
   "main": "./index",
   "scripts": {
     "test": "make test"


### PR DESCRIPTION
With the rise in supply chain attacks and OSS dependencies being used as a attack vector, Microsoft is working with our ecosystem partners, such as the Linux Foundation's OpenSSF, to enable OSS consumers to track packages back to their public sources.
We've identified that the following packages published to NPM do not report where sources can be found, typically accomplished by including a link to your GitHub repository in your `package.json` REPOSITORY field. This PR was created to add this value, ensuring future releases will include this provenance information.
Published NPM packages with repository information:
* urun